### PR TITLE
Add option to configure yara rules path through env

### DIFF
--- a/workers/openrelik-worker-yara/Dockerfile
+++ b/workers/openrelik-worker-yara/Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 # Install poetry and any other dependency that your worker needs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-poetry git curl \
+    curl \
     # Mount dependencies
     sudo \
     fdisk \

--- a/workers/openrelik-worker-yara/README.md
+++ b/workers/openrelik-worker-yara/README.md
@@ -24,6 +24,7 @@ openrelik-worker-yara:
   restart: always
   environment:
     - REDIS_URL=redis://openrelik-redis:6379
+    - YARA_RULES_FOLDER=/data/yara/
   volumes:
     - ./data:/usr/share/openrelik/data
     - /dev:/dev

--- a/workers/openrelik-worker-yara/src/tasks.py
+++ b/workers/openrelik-worker-yara/src/tasks.py
@@ -201,8 +201,18 @@ def command(
     manual_yara = task_config.get("Manual Yara rules", "")
     mount_disk_images = task_config.get("mount_disk_images", False)
 
-    if not global_yara and not manual_yara:
-        error_msg = "At least one of Global and/or Manual Yara rules must be provided"
+    # If the environment variable YARA_RULES_FOLDER is set, add it to the global Yara rules
+    env_yara = os.getenv("YARA_RULES_FOLDER", "")
+    if env_yara:
+        logger.info(
+            f"Environment variable YARA_RULES_FOLDER provided, added {env_yara} to global Yara rules"
+        )
+        global_yara += f"\n{env_yara}"
+
+    if not global_yara and not manual_yara and not env_yara:
+        error_msg = (
+            "At least one of Environment, Global or Manual Yara rules must be provided"
+        )
         logger.error(error_msg)
         raise RuntimeError(error_msg)
 


### PR DESCRIPTION
Add option to configure the yara rules folder through the environment variable `YARA_RULES_FOLDER` in addition to setting a global rules path or manual rules at runtime.