### PR TITLE
feat(timesketch-worker): add access control, analyzer execution, and UI progress reporting

### DIFF
--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -138,11 +138,12 @@ TASK_METADATA = {
             "required": False,
         },
         {
-            "name": "is_public",
-            "label": "Public",
+            "name": "make_private",
+            "label": "Set Sketch as Private",
             "description": (
-                "Make sketch public? If enabled, the sketch will be visible to "
-                "all users on the Timesketch instance."
+                "By default, sketches are public so you can view them. "
+                "If you check this, ONLY the users specified in the shared "
+                "list above will have access."
             ),
             "type": "checkbox",
             "required": False,
@@ -190,7 +191,10 @@ def upload(
     selected_analyzers = task_config.get("analyzers",[])
 
     # Extract Access Control Config safely
-    is_public = task_config.get("is_public", False)
+    make_private = task_config.get("make_private", False)
+
+    # Because it defaults to false (unchecked), is_public becomes True
+    is_public = not make_private
 
     shared_users_str = task_config.get("shared_users", "")
     shared_users = []

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -13,12 +13,32 @@
 # limitations under the License.
 
 import os
+import time
 
 from openrelik_worker_common.task_utils import create_task_result, get_input_files
 from timesketch_api_client import client as timesketch_client
 from timesketch_import_client import importer
 
 from .app import celery, redis_client
+
+# Hardcoded list of available Timesketch analyzers
+TIMESKETCH_ANALYZERS =[
+    "account_finder",
+    "browser_search",
+    "browser_timeframe",
+    "domain",
+    "feature_extraction",
+    "hashr_lookup",
+    "tagger",
+    "yetikeywords",
+    "yetibloomchecker",
+    "yetitriageindicators",
+    "yetibadnessindicators",
+    "yetilolbasindicators",
+    "yetiinvestigations"
+]
+
+TIMELINE_STATUS_TIMEOUT = 240
 
 
 def get_or_create_sketch(
@@ -75,7 +95,7 @@ TASK_NAME = "openrelik-worker-timesketch.tasks.upload"
 TASK_METADATA = {
     "display_name": "Upload to Timesketch",
     "description": "Upload resulting file to Timesketch",
-    "task_config": [
+    "task_config":[
         {
             "name": "sketch_id",
             "label": "Add to an existing sketch",
@@ -95,6 +115,16 @@ TASK_METADATA = {
             "label": "Name of the timeline to create",
             "description": "Timeline name",
             "type": "text",
+            "required": False,
+        },
+        {
+            "name": "analyzers",
+            "label": "Select Analyzers",
+            "description": (
+                "Select Timesketch Analyzers to run on the timeline after upload."
+            ),
+            "type": "autocomplete",
+            "items": TIMESKETCH_ANALYZERS,
             "required": False,
         },
         {
@@ -142,7 +172,7 @@ def upload(
     Returns:
         Base64-encoded dictionary containing task results.
     """
-    input_files = get_input_files(pipe_result, input_files or [])
+    input_files = get_input_files(pipe_result, input_files or[])
     task_config = task_config or {}
 
     # Connection details from environment variables.
@@ -156,11 +186,14 @@ def upload(
     sketch_name = task_config.get("sketch_name")
     sketch_identifier = {"sketch_id": sketch_id} if sketch_id else {"sketch_name": sketch_name}
 
+    # Analyzers config
+    selected_analyzers = task_config.get("analyzers",[])
+
     # Extract Access Control Config safely
     is_public = task_config.get("is_public", False)
 
     shared_users_str = task_config.get("shared_users", "")
-    shared_users =[]
+    shared_users = []
     if shared_users_str:
         # Split by comma, trim whitespace, and ignore empty strings
         shared_users =[u.strip() for u in shared_users_str.split(",") if u.strip()]
@@ -186,18 +219,58 @@ def upload(
     # Apply Access Controls to the sketch
     sketch.add_to_acl(make_public=is_public, user_list=shared_users)
 
-    # Import each input file to it's own index.
+    warnings =[]
+
+    # Import each input file to its own index.
     for input_file in input_files:
         input_file_path = input_file.get("path")
         timeline_name = task_config.get("timeline_name") or input_file.get("display_name")
+
+        timeline = None
         with importer.ImportStreamer() as streamer:
             streamer.set_sketch(sketch)
             streamer.set_timeline_name(timeline_name)
             streamer.add_file(input_file_path)
 
+            # Grab the timeline object before context closes so we can query it later
+            timeline = streamer.timeline
+
+        # If the user selected analyzers, we must wait for indexing to complete
+        if selected_analyzers and timeline:
+            max_retries = TIMELINE_STATUS_TIMEOUT  # Wait up to 20 minutes (120 * 5s) for indexing to finish
+            retry_count = 0
+
+            while retry_count < max_retries:
+                if timeline.status == "ready":
+                    break
+                retry_count += 1
+                time.sleep(5)
+
+            # Once ready, trigger the analyzers
+            if timeline.status == "ready":
+                for analyzer in selected_analyzers:
+                    timeline.run_analyzer(analyzer)
+            else:
+                # Add a warning message if it timed out
+                warning_msg = (
+                    f"Analyzers for timeline '{timeline_name}' were skipped "
+                    "because the timeline was not ready within "
+                    f"{TIMELINE_STATUS_TIMEOUT*5} seconds!"
+                )
+                warnings.append(warning_msg)
+
+    # Create the metadata dictionary
+    meta_result = {
+        "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}"
+    }
+
+    # If any warnings occurred, append them so they appear in the UI
+    if warnings:
+        meta_result["Warnings"] = warnings
+
     return create_task_result(
         output_files=[],
         workflow_id=workflow_id,
         command="Timesketch Importer Client",
-        meta={"sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}"},
+        meta=meta_result,
     )

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -205,6 +205,9 @@ def upload(
         password=timesketch_password,
     )
 
+    # UI Update: Initializing
+    self.send_event("task-progress", data={"status": "Connecting to Timesketch API and configuring Sketch..."})
+
     # Get or create sketch using a distributed lock.
     sketch = get_or_create_sketch(
         timesketch_api_client,
@@ -220,13 +223,30 @@ def upload(
     sketch.add_to_acl(make_public=is_public, user_list=shared_users)
 
     warnings =[]
+    total_files = len(input_files)
 
     # Import each input file to its own index.
-    for input_file in input_files:
+    for index, input_file in enumerate(input_files, start=1):
         input_file_path = input_file.get("path")
-        timeline_name = task_config.get("timeline_name") or input_file.get("display_name")
+        file_display_name = input_file.get("display_name")
+
+        # Prevent identical timeline names if multiple files are processed
+        base_name = task_config.get("timeline_name")
+        if base_name and total_files > 1:
+            timeline_name = f"{base_name} - {file_display_name}"
+        else:
+            timeline_name = base_name or file_display_name
 
         timeline = None
+
+        # UI Update: Uploading
+        self.send_event("task-progress", data={
+            "status": "Uploading file to Timesketch",
+            "progress": f"File {index} of {total_files}",
+            "current_file": file_display_name,
+            "timeline_name": timeline_name
+        })
+
         with importer.ImportStreamer() as streamer:
             streamer.set_sketch(sketch)
             streamer.set_timeline_name(timeline_name)
@@ -237,17 +257,39 @@ def upload(
 
         # If the user selected analyzers, we must wait for indexing to complete
         if selected_analyzers and timeline:
-            max_retries = TIMELINE_STATUS_TIMEOUT  # Wait up to 20 minutes (120 * 5s) for indexing to finish
+            max_retries = TIMELINE_STATUS_TIMEOUT
             retry_count = 0
 
             while retry_count < max_retries:
-                if timeline.status == "ready":
+                # Always fetch the latest status to display
+                current_status = timeline.status
+
+                # UI Update: Indexing
+                self.send_event("task-progress", data={
+                    "status": "Waiting for Timesketch internal indexing to finish",
+                    "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
+                    "progress": f"File {index} of {total_files}",
+                    "current_file": file_display_name,
+                    "timesketch_status": current_status,
+                    "time_elapsed": f"{retry_count * 5}s (Timeout at {max_retries * 5}s)"
+                })
+
+                if current_status == "ready":
                     break
                 retry_count += 1
                 time.sleep(5)
 
             # Once ready, trigger the analyzers
             if timeline.status == "ready":
+                # UI Update: Triggering analyzers
+                self.send_event("task-progress", data={
+                    "status": "Triggering Analyzers in Timesketch",
+                    "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
+                    "progress": f"File {index} of {total_files}",
+                    "current_file": file_display_name,
+                    "analyzers_queued": len(selected_analyzers)
+                })
+
                 for analyzer in selected_analyzers:
                     timeline.run_analyzer(analyzer)
             else:
@@ -266,7 +308,10 @@ def upload(
 
     # If any warnings occurred, append them so they appear in the UI
     if warnings:
-        meta_result["Warnings"] = warnings
+        meta_result["warnings"] = warnings
+
+    # UI Update: Finished
+    self.send_event("task-progress", data={"status": "Done! Finished exporting to Timesketch."})
 
     return create_task_result(
         output_files=[],

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -22,7 +22,7 @@ from timesketch_import_client import importer
 from .app import celery, redis_client
 
 # Hardcoded list of available Timesketch analyzers
-TIMESKETCH_ANALYZERS =[
+TIMESKETCH_ANALYZERS = [
     "account_finder",
     "browser_search",
     "browser_timeframe",
@@ -35,18 +35,19 @@ TIMESKETCH_ANALYZERS =[
     "yetitriageindicators",
     "yetibadnessindicators",
     "yetilolbasindicators",
-    "yetiinvestigations"
+    "yetiinvestigations",
 ]
 
-TIMELINE_STATUS_TIMEOUT = 240
+MAX_INDEXING_RETRIES = 240
+POLL_INTERVAL_SECONDS = 5
 
 
 def get_or_create_sketch(
     timesketch_api_client,
     redis_client,
-    sketch_id=None,
-    sketch_name=None,
-    workflow_id=None,
+    sketch_id: int | str | None = None,
+    sketch_name: str | None = None,
+    workflow_id: str | None = None,
 ):
     """
     Retrieves or creates a sketch, handling locking if needed.
@@ -95,7 +96,7 @@ TASK_NAME = "openrelik-worker-timesketch.tasks.upload"
 TASK_METADATA = {
     "display_name": "Upload to Timesketch",
     "description": "Upload resulting file to Timesketch",
-    "task_config":[
+    "task_config": [
         {
             "name": "sketch_id",
             "label": "Add to an existing sketch",
@@ -173,7 +174,7 @@ def upload(
     Returns:
         Base64-encoded dictionary containing task results.
     """
-    input_files = get_input_files(pipe_result, input_files or[])
+    input_files = get_input_files(pipe_result, input_files or [])
     task_config = task_config or {}
 
     # Connection details from environment variables.
@@ -185,10 +186,9 @@ def upload(
     # User supplied config.
     sketch_id = task_config.get("sketch_id")
     sketch_name = task_config.get("sketch_name")
-    sketch_identifier = {"sketch_id": sketch_id} if sketch_id else {"sketch_name": sketch_name}
 
     # Analyzers config
-    selected_analyzers = task_config.get("analyzers",[])
+    selected_analyzers = task_config.get("analyzers", [])
 
     # Extract Access Control Config safely
     make_private = task_config.get("make_private", False)
@@ -200,7 +200,7 @@ def upload(
     shared_users = []
     if shared_users_str:
         # Split by comma, trim whitespace, and ignore empty strings
-        shared_users =[u.strip() for u in shared_users_str.split(",") if u.strip()]
+        shared_users = [u.strip() for u in shared_users_str.split(",") if u.strip()]
 
     # Create a Timesketch API client.
     timesketch_api_client = timesketch_client.TimesketchApi(
@@ -210,13 +210,17 @@ def upload(
     )
 
     # UI Update: Initializing
-    self.send_event("task-progress", data={"status": "Connecting to Timesketch API and configuring Sketch..."})
+    self.send_event(
+        "task-progress",
+        data={"status": "Connecting to Timesketch API and configuring Sketch..."},
+    )
 
     # Get or create sketch using a distributed lock.
     sketch = get_or_create_sketch(
         timesketch_api_client,
         redis_client,
-        **sketch_identifier,
+        sketch_id=sketch_id,
+        sketch_name=sketch_name,
         workflow_id=workflow_id,
     )
 
@@ -226,7 +230,7 @@ def upload(
     # Apply Access Controls to the sketch
     sketch.add_to_acl(make_public=is_public, user_list=shared_users)
 
-    warnings =[]
+    warnings = []
     uploaded_timelines = []
     total_files = len(input_files)
 
@@ -245,12 +249,15 @@ def upload(
         timeline = None
 
         # UI Update: Uploading
-        self.send_event("task-progress", data={
-            "status": "Uploading file to Timesketch",
-            "progress": f"File {index} of {total_files}",
-            "current_file": file_display_name,
-            "timeline_name": timeline_name
-        })
+        self.send_event(
+            "task-progress",
+            data={
+                "status": "Uploading file to Timesketch",
+                "progress": f"File {index} of {total_files}",
+                "current_file": file_display_name,
+                "timeline_name": timeline_name,
+            },
+        )
 
         with importer.ImportStreamer() as streamer:
             streamer.set_sketch(sketch)
@@ -262,14 +269,11 @@ def upload(
 
         # Append to our summary list
         if timeline:
-            uploaded_timelines.append({
-                "ID": timeline.id,
-                "Name": timeline.name
-            })
+            uploaded_timelines.append({"ID": timeline.id, "Name": timeline.name})
 
         # If the user selected analyzers, we must wait for indexing to complete
         if selected_analyzers and timeline:
-            max_retries = TIMELINE_STATUS_TIMEOUT
+            max_retries = MAX_INDEXING_RETRIES
             retry_count = 0
 
             while retry_count < max_retries:
@@ -277,30 +281,36 @@ def upload(
                 current_status = timeline.status
 
                 # UI Update: Indexing
-                self.send_event("task-progress", data={
-                    "status": "Waiting for Timesketch internal indexing to finish",
-                    "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
-                    "progress": f"File {index} of {total_files}",
-                    "current_file": file_display_name,
-                    "timesketch_status": current_status,
-                    "time_elapsed": f"{retry_count * 5}s (Timeout at {max_retries * 5}s)"
-                })
+                self.send_event(
+                    "task-progress",
+                    data={
+                        "status": "Waiting for Timesketch internal indexing to finish",
+                        "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
+                        "progress": f"File {index} of {total_files}",
+                        "current_file": file_display_name,
+                        "timesketch_status": current_status,
+                        "time_elapsed": f"{retry_count * POLL_INTERVAL_SECONDS}s (Timeout at {max_retries * POLL_INTERVAL_SECONDS}s)",
+                    },
+                )
 
                 if current_status == "ready":
                     break
                 retry_count += 1
-                time.sleep(5)
+                time.sleep(POLL_INTERVAL_SECONDS)
 
             # Once ready, trigger the analyzers
             if timeline.status == "ready":
                 # UI Update: Triggering analyzers
-                self.send_event("task-progress", data={
-                    "status": "Triggering Analyzers in Timesketch",
-                    "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
-                    "progress": f"File {index} of {total_files}",
-                    "current_file": file_display_name,
-                    "analyzers_queued": len(selected_analyzers)
-                })
+                self.send_event(
+                    "task-progress",
+                    data={
+                        "status": "Triggering Analyzers in Timesketch",
+                        "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
+                        "progress": f"File {index} of {total_files}",
+                        "current_file": file_display_name,
+                        "analyzers_queued": len(selected_analyzers),
+                    },
+                )
 
                 for analyzer in selected_analyzers:
                     timeline.run_analyzer(analyzer)
@@ -309,7 +319,7 @@ def upload(
                 warning_msg = (
                     f"Analyzers for timeline '{timeline_name}' were skipped "
                     "because the timeline was not ready within "
-                    f"{TIMELINE_STATUS_TIMEOUT*5} seconds!"
+                    f"{max_retries * POLL_INTERVAL_SECONDS} seconds!"
                 )
                 warnings.append(warning_msg)
 
@@ -320,7 +330,7 @@ def upload(
 
     # Flatten the uploaded timelines into a single, readable string
     timelines_summary = ", ".join(
-        [f"\"{t['Name']}\" (ID: {t['ID']})" for t in uploaded_timelines]
+        f'"{t["Name"]}" (ID: {t["ID"]})' for t in uploaded_timelines
     )
     if timelines_summary:
         meta_result["uploaded_timelines"] = timelines_summary
@@ -330,7 +340,9 @@ def upload(
         meta_result["warnings"] = " | ".join(warnings)
 
     # UI Update: Finished
-    self.send_event("task-progress", data={"status": "Done! Finished exporting to Timesketch."})
+    self.send_event(
+        "task-progress", data={"status": "Done! Finished exporting to Timesketch."}
+    )
 
     return create_task_result(
         output_files=[],

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -30,7 +30,7 @@ def get_or_create_sketch(
 ):
     """
     Retrieves or creates a sketch, handling locking if needed.
-    This uses Redis distrubuted lock to avoid race conditions.
+    This uses Redis distributed lock to avoid race conditions.
 
     Args:
         client: Timesketch API client.
@@ -97,6 +97,26 @@ TASK_METADATA = {
             "type": "text",
             "required": False,
         },
+        {
+            "name": "shared_users",
+            "label": "Share with Timesketch users",
+            "description": (
+                "Comma-separated list of Timesketch usernames to share the "
+                "sketch with (e.g., admin,user1@example.com)."
+            ),
+            "type": "text",
+            "required": False,
+        },
+        {
+            "name": "is_public",
+            "label": "Public",
+            "description": (
+                "Make sketch public? If enabled, the sketch will be visible to "
+                "all users on the Timesketch instance."
+            ),
+            "type": "checkbox",
+            "required": False,
+        },
     ],
 }
 
@@ -123,6 +143,7 @@ def upload(
         Base64-encoded dictionary containing task results.
     """
     input_files = get_input_files(pipe_result, input_files or [])
+    task_config = task_config or {}
 
     # Connection details from environment variables.
     timesketch_server_url = os.environ.get("TIMESKETCH_SERVER_URL")
@@ -134,6 +155,15 @@ def upload(
     sketch_id = task_config.get("sketch_id")
     sketch_name = task_config.get("sketch_name")
     sketch_identifier = {"sketch_id": sketch_id} if sketch_id else {"sketch_name": sketch_name}
+
+    # Extract Access Control Config safely
+    is_public = task_config.get("is_public", False)
+
+    shared_users_str = task_config.get("shared_users", "")
+    shared_users =[]
+    if shared_users_str:
+        # Split by comma, trim whitespace, and ignore empty strings
+        shared_users =[u.strip() for u in shared_users_str.split(",") if u.strip()]
 
     # Create a Timesketch API client.
     timesketch_api_client = timesketch_client.TimesketchApi(
@@ -153,9 +183,8 @@ def upload(
     if not sketch:
         raise Exception(f"Failed to create or retrieve sketch '{sketch_name}'")
 
-    # Make the sketch public.
-    # TODO: Make this user configurable.
-    sketch.add_to_acl(make_public=True)
+    # Apply Access Controls to the sketch
+    sketch.add_to_acl(make_public=is_public, user_list=shared_users)
 
     # Import each input file to it's own index.
     for input_file in input_files:

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -66,7 +66,10 @@ def get_or_create_sketch(
     sketch = None
 
     if sketch_id:
-        sketch = timesketch_api_client.get_sketch(int(sketch_id))
+        try:
+            sketch = timesketch_api_client.get_sketch(int(sketch_id))
+        except ValueError:
+            raise ValueError(f"Sketch ID must be a number. Received: '{sketch_id}'")
     elif sketch_name:
         sketch = timesketch_api_client.create_sketch(sketch_name)
     else:
@@ -121,9 +124,7 @@ TASK_METADATA = {
         {
             "name": "analyzers",
             "label": "Select Analyzers",
-            "description": (
-                "Select Timesketch Analyzers to run on the timeline after upload."
-            ),
+            "description": "Select Timesketch Analyzers to run on the timeline after upload.",
             "type": "autocomplete",
             "items": TIMESKETCH_ANALYZERS,
             "required": False,
@@ -179,6 +180,11 @@ def upload(
 
     # Connection details from environment variables.
     timesketch_server_url = os.environ.get("TIMESKETCH_SERVER_URL")
+    if not timesketch_server_url:
+        raise RuntimeError(
+            "TIMESKETCH_SERVER_URL environment variable is not set on the worker."
+        )
+
     timesketch_server_public_url = os.environ.get("TIMESKETCH_SERVER_PUBLIC_URL")
     timesketch_username = os.environ.get("TIMESKETCH_USERNAME")
     timesketch_password = os.environ.get("TIMESKETCH_PASSWORD")
@@ -192,8 +198,12 @@ def upload(
 
     # Extract Access Control Config safely
     make_private = task_config.get("make_private", False)
+    if isinstance(make_private, str):
+        make_private = make_private.lower() in ["true", "1", "yes"]
+    else:
+        make_private = bool(make_private)
 
-    # Because it defaults to false (unchecked), is_public becomes True
+    # Public Sketch is the default!
     is_public = not make_private
 
     shared_users_str = task_config.get("shared_users", "")
@@ -225,7 +235,9 @@ def upload(
     )
 
     if not sketch:
-        raise Exception(f"Failed to create or retrieve sketch '{sketch_name}'")
+        raise Exception(
+            f"Failed to create or retrieve sketch '{sketch_name or sketch_id}'"
+        )
 
     # Apply Access Controls to the sketch
     sketch.add_to_acl(make_public=is_public, user_list=shared_users)
@@ -293,8 +305,9 @@ def upload(
                     },
                 )
 
-                if current_status == "ready":
+                if current_status in ["ready", "fail"]:
                     break
+
                 retry_count += 1
                 time.sleep(POLL_INTERVAL_SECONDS)
 
@@ -314,14 +327,15 @@ def upload(
 
                 for analyzer in selected_analyzers:
                     timeline.run_analyzer(analyzer)
+            elif timeline.status == "fail":
+                warnings.append(
+                    f"Analyzers for timeline '{timeline_name}' skipped because Timesketch failed to index the file."
+                )
             else:
-                # Add a warning message if it timed out
-                warning_msg = (
-                    f"Analyzers for timeline '{timeline_name}' were skipped "
-                    "because the timeline was not ready within "
+                warnings.append(
+                    f"Analyzers for timeline '{timeline_name}' skipped because it was not ready within "
                     f"{max_retries * POLL_INTERVAL_SECONDS} seconds!"
                 )
-                warnings.append(warning_msg)
 
     # Create the metadata dictionary
     meta_result = {

--- a/workers/openrelik-worker-timesketch/src/tasks.py
+++ b/workers/openrelik-worker-timesketch/src/tasks.py
@@ -227,6 +227,7 @@ def upload(
     sketch.add_to_acl(make_public=is_public, user_list=shared_users)
 
     warnings =[]
+    uploaded_timelines = []
     total_files = len(input_files)
 
     # Import each input file to its own index.
@@ -258,6 +259,13 @@ def upload(
 
             # Grab the timeline object before context closes so we can query it later
             timeline = streamer.timeline
+
+        # Append to our summary list
+        if timeline:
+            uploaded_timelines.append({
+                "ID": timeline.id,
+                "Name": timeline.name
+            })
 
         # If the user selected analyzers, we must wait for indexing to complete
         if selected_analyzers and timeline:
@@ -307,12 +315,19 @@ def upload(
 
     # Create the metadata dictionary
     meta_result = {
-        "Sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}"
+        "sketch": f"{timesketch_server_public_url}/sketch/{sketch.id}",
     }
+
+    # Flatten the uploaded timelines into a single, readable string
+    timelines_summary = ", ".join(
+        [f"\"{t['Name']}\" (ID: {t['ID']})" for t in uploaded_timelines]
+    )
+    if timelines_summary:
+        meta_result["uploaded_timelines"] = timelines_summary
 
     # If any warnings occurred, append them so they appear in the UI
     if warnings:
-        meta_result["warnings"] = warnings
+        meta_result["warnings"] = " | ".join(warnings)
 
     # UI Update: Finished
     self.send_event("task-progress", data={"status": "Done! Finished exporting to Timesketch."})


### PR DESCRIPTION
This PR enhances the Timesketch export worker by introducing sketch access controls, automated analyzer execution post-upload, and real-time task progress reporting for the OpenRelik UI. It also includes several stability improvements for API interactions.

**Key Changes:**

* **Access Control Management:** 
  * Added `make_private` (checkbox) and `shared_users` (text) options to the task configuration. 
  * Sketches still default to public to prevent orphaned data (created by the service account), but can be explicitly marked as private and shared with specific Timesketch users via the API's `add_to_acl` method.
* **Automated Analyzer Execution:** 
  * Introduced an `analyzers` config field with a predefined list of Timesketch analyzers.
  * Implemented a polling loop that safely waits for Timesketch's internal indexing to finish (`timeline.status == "ready"`) before triggering the selected analyzers. 
  * Added timeout handling and early-exit logic if Timesketch returns a `"fail"` status during indexing.
* **UI Progress & Metadata Enhancements:** 
  * Implemented `self.send_event("task-progress", ...)` to stream granular real-time status updates (e.g., Uploading, Indexing polling intervals, Triggering analyzers) back to the OpenRelik UI.
  * Added a formatted summary of uploaded timelines (Name and ID) and any skipped-analyzer warnings to the returned `meta` dictionary. Formatted as flat strings to ensure the OpenRelik UI properly renders the output table and preserves clickable Sketch URLs.
* **Stability & Error Handling Improvements:**
  * Added fail-fast validation for required environment variables (e.g., `TIMESKETCH_SERVER_URL`).
  * Implemented safe casting and exception handling for `sketch_id` inputs.
  * Added safe parsing for checkbox values to handle string-based booleans from frontend payloads.