### PR TITLE
image_export: optional SHA-256 hash manifest for extracted files

### DIFF
--- a/workers/extraction/src/image_export.py
+++ b/workers/extraction/src/image_export.py
@@ -97,6 +97,18 @@ TASK_METADATA = {
             "required": False,
         },
         {
+            "name": "calculate_hashes",
+            "label": "Calculate SHA-256 hashes for extracted files",
+            "description": (
+                "Also register the hashes.json manifest that image_export.py "
+                "writes (in-image path to SHA-256) as an output file with "
+                "data type extraction:image_export:hashes, so downstream "
+                "workers can use ready-made digests."
+            ),
+            "type": "checkbox",
+            "required": False,
+        },
+        {
             "name": "file_signatures",
             "label": "Select file format signatures to filter on",
             "description": "Filter on file format signature identifiers.",
@@ -144,6 +156,8 @@ def extract_task(
     log_root.bind(workflow_id=workflow_id)
     logger.info(f"Starting {TASK_NAME} for workflow {workflow_id}")
 
+    calculate_hashes = bool((task_config or {}).get("calculate_hashes"))
+
     def _get_base_command(export_directory):
         """Get the base command for image_export.
 
@@ -151,9 +165,8 @@ def extract_task(
             export_directory: Directory to export files to.
         """
 
-        return [
+        command = [
             "image_export.py",
-            "--no-hashes",
             "--write",
             export_directory,
             "--partitions",
@@ -162,6 +175,9 @@ def extract_task(
             "all",
             "--unattended",
         ]
+        if not calculate_hashes:
+            command.insert(1, "--no-hashes")
+        return command
 
     input_files = get_input_files(pipe_result, input_files or [])
     output_files = []
@@ -242,6 +258,23 @@ def extract_task(
                 # We need to hard ignore this file as image_export.py creates
                 # this file in a fixed path and filename.
                 if "artifacts_map.json" in file.absolute().name:
+                    continue
+                # image_export.py writes a hashes.json manifest at the export
+                # root when hashing is enabled. Register it with a dedicated
+                # data type instead of treating it as an extracted file.
+                if (
+                    calculate_hashes
+                    and file.name == "hashes.json"
+                    and file.parent == export_directory_path
+                ):
+                    manifest_file = create_output_file(
+                        output_path,
+                        display_name="hashes.json",
+                        data_type="extraction:image_export:hashes",
+                        source_file_id=input_file.get("id"),
+                    )
+                    shutil.copy(file.absolute(), manifest_file.path)
+                    output_files.append(manifest_file.to_dict())
                     continue
                 original_path = str(file.relative_to(export_directory_path))
                 artifact_types = get_artifact_types(

--- a/workers/extraction/tests/test_image_export.py
+++ b/workers/extraction/tests/test_image_export.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import json
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -361,3 +363,111 @@ def test_extract_task_output_processing_with_artifact_types(
     )
 
     assert mock_dependencies["create_output_file"].call_count == 2
+
+
+@patch("src.image_export.telemetry")
+def test_extract_task_hashes_disabled_by_default(
+    mock_telemetry, mock_celery_task, mock_dependencies
+):
+    """Test that image_export runs with --no-hashes unless requested."""
+    mock_dependencies["get_input_files"].return_value = [{"path": "test.dd", "id": "1"}]
+    mock_dependencies["create_task_result"].return_value = "task_result"
+
+    mock_process = MagicMock()
+    mock_process.poll.return_value = 0
+    mock_process.stdout.read.return_value = "Process output"
+    mock_process.stderr.read.return_value = ""
+    mock_dependencies["popen"].return_value = mock_process
+    mock_dependencies["glob"].return_value = []
+
+    extract_task.__class__.run(
+        mock_celery_task,
+        task_config={"filenames": "evil.exe"},
+        output_path="/tmp/output",
+        workflow_id="workflow-123",
+    )
+
+    call_args = mock_dependencies["popen"].call_args[0][0]
+    assert "--no-hashes" in call_args
+
+
+@patch("src.image_export.telemetry")
+def test_extract_task_calculate_hashes_enables_hashing(
+    mock_telemetry, mock_celery_task, mock_dependencies
+):
+    """Test that calculate_hashes removes --no-hashes from the command."""
+    mock_dependencies["get_input_files"].return_value = [{"path": "test.dd", "id": "1"}]
+    mock_dependencies["create_task_result"].return_value = "task_result"
+
+    mock_process = MagicMock()
+    mock_process.poll.return_value = 0
+    mock_process.stdout.read.return_value = "Process output"
+    mock_process.stderr.read.return_value = ""
+    mock_dependencies["popen"].return_value = mock_process
+    mock_dependencies["glob"].return_value = []
+
+    extract_task.__class__.run(
+        mock_celery_task,
+        task_config={"filenames": "evil.exe", "calculate_hashes": True},
+        output_path="/tmp/output",
+        workflow_id="workflow-123",
+    )
+
+    call_args = mock_dependencies["popen"].call_args[0][0]
+    assert "--no-hashes" not in call_args
+
+
+@patch("src.image_export.telemetry")
+def test_extract_task_registers_hash_manifest(
+    mock_telemetry, mock_celery_task, tmp_path
+):
+    """Test that the hashes.json manifest is registered with its data type."""
+    export_root = None
+
+    def fake_popen(command, **kwargs):
+        # image_export.py writes hashes.json at the export root; emulate it.
+        nonlocal export_root
+        export_root = command[command.index("--write") + 1]
+        manifest = Path(export_root) / "hashes.json"
+        manifest.write_text(json.dumps([{"sha256": "a" * 64, "paths": ["/bin/ls"]}]))
+        process = MagicMock()
+        process.poll.return_value = 0
+        process.stdout.read.return_value = ""
+        process.stderr.read.return_value = ""
+        return process
+
+    created = []
+
+    def fake_create_output_file(output_path, **kwargs):
+        output_file = MagicMock()
+        output_file.path = str(tmp_path / f"out-{len(created)}")
+        output_file.to_dict.return_value = kwargs
+        created.append(kwargs)
+        return output_file
+
+    with (
+        patch("src.image_export.get_input_files") as mock_get_input_files,
+        patch(
+            "src.image_export.create_output_file",
+            side_effect=fake_create_output_file,
+        ),
+        patch("src.image_export.create_task_result") as mock_create_task_result,
+        patch("src.image_export.subprocess.Popen", side_effect=fake_popen),
+        patch("src.image_export.shutil.rmtree"),
+        patch("src.image_export.shutil.copy"),
+    ):
+        mock_get_input_files.return_value = [{"path": "test.dd", "id": "1"}]
+        mock_create_task_result.return_value = "task_result"
+
+        extract_task.__class__.run(
+            mock_celery_task,
+            task_config={"filenames": "evil.exe", "calculate_hashes": True},
+            output_path=str(tmp_path),
+            workflow_id="workflow-123",
+        )
+
+    manifests = [
+        c for c in created if c.get("data_type") == "extraction:image_export:hashes"
+    ]
+    assert len(manifests) == 1
+    assert manifests[0]["display_name"] == "hashes.json"


### PR DESCRIPTION
## Summary

Adds an optional `calculate_hashes` setting to the image_export task. When enabled, the `--no-hashes` flag is dropped so Plaso's image_export calculates SHA-256 digests during extraction, and the `hashes.json` manifest it writes is registered as a dedicated output file with `data_type="extraction:image_export:hashes"`.

Motivation: enrichment and triage workers downstream of a disk-image extraction (reputation lookups, hash-prevalence checks) need a digest for every extracted file. Today each worker has to re-hash every file independently; image_export already reads all the bytes during extraction, so letting it produce the digests once and publishing the manifest with a stable data type gives downstream workers a shared, cheap source of file hashes with original in-image paths.

Default behavior is unchanged (`--no-hashes` is still passed unless the option is enabled).

## Testing

Validated on a live deployment against a raw FAT disk image: with the option enabled, `hashes.json` is emitted with the dedicated data type alongside the extracted files, digests match independently-computed SHA-256 values for all extracted files, and a downstream worker consumed the manifest via the data type. With the option disabled, behavior and outputs are identical to before the change.
