### PR TITLE
strings: wait for the subprocess instead of sleeping per poll tick

### DIFF
--- a/workers/strings/src/tasks.py
+++ b/workers/strings/src/tasks.py
@@ -121,19 +121,25 @@ def strings(
                 start_time = datetime.now()
                 update_interval_s = 3
 
-                while process.poll() is None:
-                    extracted_strings = count_file_lines(output_file.path)
-                    duration = datetime.now() - start_time
-                    rate = (
-                        int(extracted_strings / duration.total_seconds())
-                        if duration.total_seconds() > 0
-                        else 0
-                    )
-                    self.send_event(
-                        "task-progress",
-                        data={"extracted_strings": extracted_strings, "rate": rate},
-                    )
-                    time.sleep(update_interval_s)
+                # Block until exit; emit progress only while a file is still
+                # being processed. Polling with a fixed sleep per file made
+                # multi-thousand-file workflows take hours of pure sleep.
+                while True:
+                    try:
+                        process.wait(timeout=update_interval_s)
+                        break
+                    except subprocess.TimeoutExpired:
+                        extracted_strings = count_file_lines(output_file.path)
+                        duration = datetime.now() - start_time
+                        rate = (
+                            int(extracted_strings / duration.total_seconds())
+                            if duration.total_seconds() > 0
+                            else 0
+                        )
+                        self.send_event(
+                            "task-progress",
+                            data={"extracted_strings": extracted_strings, "rate": rate},
+                        )
             output_files.append(output_file.to_dict())
 
     if not output_files:

--- a/workers/strings/tests/test_tasks.py
+++ b/workers/strings/tests/test_tasks.py
@@ -55,8 +55,14 @@ def test_strings_task_success(
     }
     mock_create_output.return_value = mock_output_file
 
+    import subprocess as _subprocess
+
     mock_process = mock.Mock()
-    mock_process.poll.side_effect = [None, 0]  # Run once then finish
+    # One progress tick (timeout) then completion.
+    mock_process.wait.side_effect = [
+        _subprocess.TimeoutExpired(cmd="strings", timeout=3),
+        0,
+    ]
     mock_popen.return_value = mock_process
 
     mock_count_lines.return_value = 100


### PR DESCRIPTION
## Summary

The strings task polls the subprocess with a fixed 3-second sleep per iteration, and the loop runs at least one iteration for every input file — even when `strings` finishes in milliseconds. Each iteration also re-counts the output file's lines from the start. On workflows with many input files this dominates wall-clock time: a disk-image workflow that extracted ~8,000 files (≈16,000 strings invocations across two encodings) spent over half a day almost entirely asleep.

This change blocks on `process.wait(timeout=...)` instead: files that finish quickly complete with zero added latency, while long-running extractions still emit the same `task-progress` events (line count + rate) every interval.

## Testing

Updated the existing unit test to drive the wait-based loop (one `TimeoutExpired` tick asserts the progress event, then completion); suite passes. Live before/after on the same deployment and the same ~8,000-file input set: the task went from making no visible progress for hours (projected ~13h of cumulative sleeps) to completing in well under an hour, with progress events still emitted for the large binaries.
