### PR TITLE
Update github actions to use Node24

### DIFF
--- a/.github/workflows/api-docs-publish-lib-common.yml
+++ b/.github/workflows/api-docs-publish-lib-common.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: lib/
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install the latest version of uv

--- a/.github/workflows/docker-image-build-log2timeline-staging.yaml
+++ b/.github/workflows/docker-image-build-log2timeline-staging.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       services: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Remove the first part of the service path (e.g. workers/) as service name
       # Example workers/openrelik-worker-extraction -> openrelik-worker-extraction

--- a/.github/workflows/docker-image-build-release.yaml
+++ b/.github/workflows/docker-image-build-release.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       services: ${{ steps.set-services.outputs.services }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Combine filters
         run: awk 1 .github/repos-uv.yaml > combined-repos.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Clean Service Name
         id: vars

--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       services: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Combine filters
         run: awk 1 .github/repos-uv.yaml > combined-repos.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # DYNAMIC STRIPPING: Removes everything up to the first '/'
       - name: Set Clean Service Name

--- a/.github/workflows/publish-pypi-common.yaml
+++ b/.github/workflows/publish-pypi-common.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Install and configure uv
       - name: Install the latest version of uv
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/python-test-lib-common.yaml
+++ b/.github/workflows/python-test-lib-common.yaml
@@ -23,7 +23,7 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:

--- a/.github/workflows/python-test-uv.yaml
+++ b/.github/workflows/python-test-uv.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -40,16 +40,16 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5 
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
         cache-dependency-glob: "${{ matrix.package }}/uv.lock"
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/update-uv-and-run-tests.yaml
+++ b/.github/workflows/update-uv-and-run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-matrix
         run: |
           SERVICES=$(find . -name "uv.lock" | xargs -n 1 dirname | jq -R . | jq -s -c .)
@@ -30,16 +30,16 @@ jobs:
         working-directory: ${{ matrix.service }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5 
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
         cache-dependency-glob: "${{ matrix.service }}/uv.lock"
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
    
     - name: Upgrade Python dependencies with uv
       run: uv lock --upgrade

--- a/.github/workflows/update-uv-workers.yaml
+++ b/.github/workflows/update-uv-workers.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-matrix
         run: |
           SERVICES=$(find ${{ env.ROOT_DIR }} -name "uv.lock" | xargs -n 1 dirname | xargs -n 1 basename | jq -R . | jq -s -c .)
@@ -30,8 +30,8 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.list-services.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       
       - name: Update Lockfile and Capture Output
         working-directory: ${{ env.ROOT_DIR }}/${{ matrix.service }}
@@ -54,7 +54,7 @@ jobs:
     if: ${{ needs.list-services.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all updates
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Node20 will be deprecated on Jun 16, 2026. This PR upgrades the github actions that have a dependency that uses Node 20.

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

