### PR TITLE
feat: Add CVE-2022-0543 detection to Redis analyzer

### DIFF
--- a/workers/analyzer-config/src/analyzers/redis_analyzer.py
+++ b/workers/analyzer-config/src/analyzers/redis_analyzer.py
@@ -36,6 +36,9 @@ def analyze_config(input_file: dict, task_config: dict) -> Report:
     bind_everywhere_re = re.compile(r'^\s*bind[\s"]*0\.0\.0\.0', re.IGNORECASE | re.MULTILINE)
     default_port_re = re.compile(r"port\s+6379\b", re.IGNORECASE)
     missing_logs_re = re.compile(r'^logfile\s+"[^"]+"$', re.MULTILINE)
+    lua_sandbox_escape_re = re.compile(
+        r"(package\.loadlib|os\.execute|io\.popen)", re.IGNORECASE
+    )
 
     if config is None or config == "":
         report.summary = "No Redis config found"
@@ -53,6 +56,13 @@ def analyze_config(input_file: dict, task_config: dict) -> Report:
         if not re.search(missing_logs_re, config):
             num_misconfigs += 1
             details_section.add_bullet("Log destination not configured")
+
+        if re.search(lua_sandbox_escape_re, config):
+            num_misconfigs += 1
+            details_section.add_bullet(
+                "Redis Lua sandbox escape (CVE-2022-0543) exploitation indicators "
+                "found (e.g. package.loadlib, os.execute)"
+            )
 
         if num_misconfigs > 0:
             report.summary = "Insecure Redis configuration found"

--- a/workers/analyzer-config/tests/test_redis_analyzer.py
+++ b/workers/analyzer-config/tests/test_redis_analyzer.py
@@ -55,6 +55,26 @@ class RedisTests(unittest.TestCase):
         self.assertEqual(result.summary, summary_expected)
         self.assertEqual(result.to_markdown(), report_expected)
 
+    def test_redisconfig_exploit(self):
+        """Test Redis config with exploit indicators."""
+        redis_config_exploit = (
+            '123:M 12 Mar 2022 10:00:00.000 * Background rewriting started\n'
+            '456:C 12 Mar 2022 10:00:01.000 * eval "package.loadlib(\'lib\', \'io\')" 0\n'
+        )
+        report_expected = (
+            """\n* Log destination not configured\n"""
+            """* Redis Lua sandbox escape (CVE-2022-0543) exploitation indicators """
+            """found (e.g. package.loadlib, os.execute)"""
+        )
+        summary_expected = "Insecure Redis configuration found"
+        with patch("builtins.open", mock_open(read_data=redis_config_exploit)):
+            result = analyze_config(self.input_file, {})
+
+        self.assertIsInstance(result, Report)
+        self.assertEqual(result.priority, Priority.HIGH)
+        self.assertEqual(result.summary, summary_expected)
+        self.assertEqual(result.to_markdown(), report_expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of the change

This PR extends the `analyzer-config` worker to detect potential exploitation indicators related to the Redis Lua sandbox escape vulnerability (CVE-2022-0543) in Redis configuration and log files. 

It implements the logic to flag instances where `package.loadlib`, `os.execute`, or `io.popen` are present, which are strong indicators of this specific sandbox escape being exploited in the wild. This mirrors a similar capability that was recently added to Turbinia.

A unit test has been added to verify that configurations containing these malicious Lua strings are appropriately flagged as High-priority issues.

### Applicable issues

- Ports Turbinia PR: https://github.com/google/turbinia/pull/1634 (or any relevant issue number)

### Additional information

This change was ported over at the suggestion of maintainers on the Turbinia project to ensure feature parity for Openrelik's Redis analysis capabilities.

### Checklist

- [X] All tests were successful.
- [X] Unit tests added.
- [ ] Documentation updated. 
