### PR TITLE
Use run rather than Popen

### DIFF
--- a/workers/yara/src/tasks.py
+++ b/workers/yara/src/tasks.py
@@ -296,14 +296,15 @@ def command(
 
         cmd = ["fraken"] + folders_and_files + [f"{all_yara.path}"]
         logger.debug(f"fraken-x command: {cmd}")
-        with open(fraken_output.path, "w+", encoding="utf-8") as log:
-            self.send_event("task-progress")
-            process = subprocess.Popen(cmd, stdout=log, stderr=subprocess.PIPE)
-            process.wait()
-            if process.stderr:
-                # Note: fraken-x uses the eprintln! Rust macro to print progress,
-                #       this outputs to stderr....
-                logger.info(f"fraken-x: {process.stderr.readlines()}")
+        self.send_event("task-progress")
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        if result.stdout:
+            with open(fraken_output.path, "wb") as f:
+                f.write(result.stdout)
+        if result.stderr:
+            # Note: fraken-x uses the eprintln! Rust macro to print progress,
+            #       this outputs to stderr....
+            logger.info(f"fraken-x: {result.stderr.splitlines()}")
     except RuntimeError as e:
         logger.error("Error encountered: %s", str(e))
     finally:

--- a/workers/yara/tests/test_tasks.py
+++ b/workers/yara/tests/test_tasks.py
@@ -165,7 +165,7 @@ def test_generate_report_from_matches():
 
 
 @patch("src.tasks.command.send_event")
-@patch("src.tasks.subprocess.Popen")
+@patch("subprocess.run")
 @patch("src.tasks.create_task_result")
 @patch("src.tasks.create_output_file")
 @patch("src.tasks.is_disk_image")
@@ -173,7 +173,7 @@ def test_command_success(
     mock_is_disk_image,
     mock_create_output_file,
     mock_create_task_result,
-    mock_popen,
+    mock_run,
     mock_send_event,
     tmp_path,
 ):
@@ -194,10 +194,11 @@ def test_command_success(
 
     mock_create_output_file.side_effect = side_effect_create_output_file
 
-    # Setup mock Popen
-    mock_process = MagicMock()
-    mock_process.stderr.readlines.return_value = []
-    mock_popen.return_value = mock_process
+    # Setup mock run
+    mock_result = MagicMock()
+    mock_result.stdout = b'[{"ImagePath": "file1.txt", "SHA256": "hash", "Signature": "rule", "Description": "desc", "Reference": "ref", "Score": 100}]\n'
+    mock_result.stderr = b""
+    mock_run.return_value = mock_result
 
     mock_create_task_result.return_value = "mock_result"
 
@@ -220,12 +221,12 @@ def test_command_success(
     )
 
     assert result == "mock_result"
-    mock_popen.assert_called_once()
+    mock_run.assert_called_once()
     mock_create_task_result.assert_called_once()
 
 
 @patch("src.tasks.command.send_event")
-@patch("src.tasks.subprocess.Popen")
+@patch("subprocess.run")
 @patch("src.tasks.create_task_result")
 @patch("src.tasks.create_output_file")
 @patch("src.tasks.BlockDevice")
@@ -235,7 +236,7 @@ def test_command_with_disk_image(
     mock_block_device,
     mock_create_output_file,
     mock_create_task_result,
-    mock_popen,
+    mock_run,
     mock_send_event,
     tmp_path,
 ):
@@ -258,10 +259,11 @@ def test_command_with_disk_image(
     mock_bd_instance.mount.return_value = [str(tmp_path / "mount1")]
     mock_block_device.return_value = mock_bd_instance
 
-    # Setup mock Popen
-    mock_process = MagicMock()
-    mock_process.stderr.readlines.return_value = []
-    mock_popen.return_value = mock_process
+    # Setup mock run
+    mock_result = MagicMock()
+    mock_result.stdout = b"[]\n"
+    mock_result.stderr = b""
+    mock_run.return_value = mock_result
 
     mock_create_task_result.return_value = "mock_result"
 


### PR DESCRIPTION
**Root Cause of the Deadlock**
The deadlock was caused by using subprocess.Popen with stdout=subprocess.PIPE and stderr=subprocess.PIPE, followed immediately by process.wait().

When pipes are used, the OS allocates a finite buffer (typically 64KB on Linux) for the data flowing from the child process to the parent. If the child process (fraken) writes more than this buffer limit (e.g., due to voluminous rule compilation errors or verbose scanning logs on stderr/stdout), it will block on the write() system call, waiting for buffer space to clear.

Because the parent Python process was blocked on process.wait() and not actively reading from the pipes, the buffer was never cleared, resulting in a deadlock: the child waiting for the parent to read, and the parent waiting for the child to exit.

**Why subprocess.run() Fixes It**
subprocess.run() (which internally uses Popen.communicate()) resolves this by actively consuming the pipes.

Instead of blocking on a simple wait, it polls the process while concurrently reading from the OS pipe buffers into Python memory (using selectors/threads under the hood). This keeps the pipe buffers drained, ensuring the child process can write all of its output and exit successfully, after which Python retrieves the full output and continues.